### PR TITLE
Revert "Allow to pass one positional arg to eosio-cpp"

### DIFF
--- a/tools/cc/eosio-cpp.cpp.in
+++ b/tools/cc/eosio-cpp.cpp.in
@@ -110,6 +110,7 @@ namespace eosio { namespace cdt {
 void generate(const std::vector<std::string>& base_options, std::string input, std::string contract_name, const std::vector<std::string>& resource_paths, bool abigen) {
    std::vector<std::string> options;
    options.push_back("eosio-cpp");
+   options.push_back(input); // don't remove oddity of CommonOptionsParser?
    options.push_back(input);
    options.push_back("--");
    for (size_t i=0; i < base_options.size(); i++) {

--- a/tools/include/compiler_options.hpp.in
+++ b/tools/include/compiler_options.hpp.in
@@ -17,7 +17,6 @@ static llvm::cl::OptionCategory EosioCompilerToolCategory("compiler options");
 #else
 static llvm::cl::OptionCategory EosioLdToolCategory("ld options");
 #endif
-static llvm::cl::OptionCategory EosioSourcePathsCategory("command-line options");
 
 /// begin ld options
 static cl::opt<bool> fquery_opt(
@@ -96,8 +95,8 @@ static cl::opt<std::string> o_opt(
 static cl::list<std::string> input_filename_opt(
       cl::Positional,
       cl::desc("<input file> ..."),
-      cl::cat(EosioSourcePathsCategory),
-      cl::ZeroOrMore);
+      cl::cat(LD_CAT),
+      cl::OneOrMore);
 static cl::opt<bool> fasm_opt(
     "fasm",
     cl::desc("Assemble file for x86-64"),


### PR DESCRIPTION
This reverts commit ad5f7135f114573f32d4bccc31c94b5f96644627.
This is not the cause of duplicated symbol error.