### PR TITLE
Fix compilation issue with GCC-9

### DIFF
--- a/tools/external/wabt/src/lexer-source.cc
+++ b/tools/external/wabt/src/lexer-source.cc
@@ -38,7 +38,7 @@ std::unique_ptr<LexerSource> LexerSourceFile::Clone() {
     result.reset();
   }
 
-  return std::move(result);
+  return result;
 }
 
 Result LexerSourceFile::Tell(Offset* out_offset) {


### PR DESCRIPTION
## Change Description

Fix compilation error:
```
[ 17%] Built target eosio-cc
/home/conr2d/eosio/eosio.cdt/tools/external/wabt/src/lexer-source.cc: In member function ‘virtual std::unique_ptr<wabt::LexerSource> wabt::LexerSourceFile::Clone()’:
/home/conr2d/eosio/eosio.cdt/tools/external/wabt/src/lexer-source.cc:41:19: error: redundant move in return statement [-Werror=redundant-move]
   41 |   return std::move(result);
      |          ~~~~~~~~~^~~~~~~~
/home/conr2d/eosio/eosio.cdt/tools/external/wabt/src/lexer-source.cc:41:19: note: remove ‘std::move’ call
cc1plus: all warnings being treated as errors
```