### PR TITLE
Set c++2a as default

### DIFF
--- a/tools/include/compiler_options.hpp.in
+++ b/tools/include/compiler_options.hpp.in
@@ -787,11 +787,11 @@ static Options CreateOptions(bool add_defaults=true) {
 #ifndef ONLY_LD
 #ifdef CPP_COMP
    if (! std_opt.empty()) {
-      copts.emplace_back("--std="+std_opt);
-      agopts.emplace_back("--std="+std_opt);
+      copts.emplace_back("-std="+std_opt);
+      agopts.emplace_back("-std="+std_opt);
    } else {
-      copts.emplace_back("--std=c++17");
-      agopts.emplace_back("--std=c++17");
+      copts.emplace_back("-std=c++2a");
+      agopts.emplace_back("-std=c++2a");
    }
 
    if (faligned_allocation_opt) {


### PR DESCRIPTION
## Change Description

eosio-cpp will have `-std=c++2a` in its compilation options by default.