### PR TITLE
Fix to invalid symbol print

### DIFF
--- a/libraries/eosiolib/core/eosio/symbol.hpp
+++ b/libraries/eosiolib/core/eosio/symbol.hpp
@@ -302,7 +302,7 @@ namespace eosio {
          char buffer[7];
          auto end = code().write_as_string( buffer, buffer + sizeof(buffer) );
          if( buffer < end )
-            ::eosio::print( buffer, (end-buffer) );
+            printl( buffer, (end-buffer) );
       }
 
       /**


### PR DESCRIPTION
## Change Description

Fix to incorrect behavior of `eosio::print(eosio::symbol)`:

``` shell
$ cleos push action test hi '["4,EOS"]' -p test
executed transaction: 2ea9c29b0371e8cdc9e03271a54c159f59b17d597b41de9ccccc23f4f1abfafc  104 bytes  100 us
#          test <= test::hi                     {"sym":"4,EOS"}
>> 4,EOS3
```