### PR TITLE
Fix brew tap install

### DIFF
--- a/scripts/generate_bottle.sh
+++ b/scripts/generate_bottle.sh
@@ -14,14 +14,14 @@ else
    MAC_VERSION="high_sierra"
 fi
 
-NAME="${PACKAGE_NAME}-${VERSION}.${MAC_VERSION}.bottle.tar.gz"
+NAME="${PACKAGE}-${VERSION}.${MAC_VERSION}.bottle.tar.gz"
 
-mkdir -p ${PROJECT}/${VERSION}/opt/eosio_cdt/lib/cmake
+mkdir -p ${PACKAGE}/${VERSION}/opt/eosio_cdt/lib/cmake
 
-PREFIX="${PROJECT}/${VERSION}"
+PREFIX="${PACKAGE}/${VERSION}"
 SPREFIX="\/usr\/local"
-SUBPREFIX="opt/${PROJECT}"
-SSUBPREFIX="opt\/${PROJECT}"
+SUBPREFIX="opt/${PACKAGE}"
+SSUBPREFIX="opt\/${PACKAGE}"
 
 export PREFIX
 export SPREFIX
@@ -41,8 +41,6 @@ echo "class Sio4Cdt < Formula
    
    option :universal
 
-   conflicts_with \"EosioCdt\", :because => "Provides same executables and libraries"
-
    depends_on \"cmake\" => :build
    depends_on \"automake\" => :build
    depends_on \"libtool\" => :build
@@ -60,10 +58,13 @@ echo "class Sio4Cdt < Formula
       root_url \"https://github.com/3osio/sio4.cdt/releases/download/v${VERSION}\"
       sha256 \"${hash}\" => :${MAC_VERSION}
    end
+
+   conflicts_with \"eosio.cdt\", :because => \"Provides same executables and libraries\"
+
    def install
       raise \"Error, only supporting binary packages at this time\"
    end
 end
-__END__" &> eosio.cdt.rb
+__END__" &> ${PACKAGE}.rb
 
-rm -r ${PROJECT}
+rm -r ${PACKAGE}

--- a/scripts/generate_deb.sh
+++ b/scripts/generate_deb.sh
@@ -2,8 +2,8 @@
 
 PREFIX="usr"
 SPREFIX=${PREFIX}
-SUBPREFIX="opt/${PROJECT}/${VERSION}"
-SSUBPREFIX="opt\/${PROJECT}\/${VERSION}"
+SUBPREFIX="opt/${PACKAGE}/${VERSION}"
+SSUBPREFIX="opt\/${PACKAGE}\/${VERSION}"
 RELEASE="${VERSION_SUFFIX}"
 
 # default release to "1" if there is no suffix
@@ -11,19 +11,20 @@ if [[ -z $RELEASE ]]; then
   RELEASE="1"
 fi
 
-NAME="${PACKAGE_NAME}_${VERSION_NO_SUFFIX}-${RELEASE}_amd64"
+NAME="${PACKAGE}_${VERSION_NO_SUFFIX}-${RELEASE}_amd64"
 
-mkdir -p ${PROJECT}/DEBIAN
-echo "Package: ${PACKAGE_NAME}
+mkdir -p ${PACKAGE}/DEBIAN
+echo "Package: ${PACKAGE}
 Version: ${VERSION_NO_SUFFIX}-${RELEASE}
 Provides: ${PROJECT}
+Conflicts: ${PROJECT}
 Replaces: ${PROJECT}
 Section: devel
 Priority: optional
 Architecture: amd64
 Homepage: ${URL} 
 Maintainer: ${EMAIL} 
-Description: ${DESC}" &> ${PROJECT}/DEBIAN/control
+Description: ${DESC}" &> ${PACKAGE}/DEBIAN/control
 
 export PREFIX
 export SUBPREFIX
@@ -32,10 +33,10 @@ export SSUBPREFIX
 
 bash generate_tarball.sh ${NAME}.tar.gz
 
-tar -xvzf ${NAME}.tar.gz -C ${PROJECT} 
-dpkg-deb --build ${PROJECT} 
+tar -xvzf ${NAME}.tar.gz -C ${PACKAGE}
+dpkg-deb --build ${PACKAGE}
 BUILDSTATUS=$?
-mv ${PROJECT}.deb ${NAME}.deb
-rm -r ${PROJECT}
+mv ${PACKAGE}.deb ${NAME}.deb
+rm -r ${PACKAGE}
 
 exit $BUILDSTATUS

--- a/scripts/generate_package.sh.in
+++ b/scripts/generate_package.sh.in
@@ -13,7 +13,7 @@ PROJECT="@PROJECT_NAME@"
 DESC="@DESC@"
 URL="@URL@"
 EMAIL="@EMAIL@"
-PACKAGE_NAME="@PACKAGE_NAME@"
+PACKAGE="@PACKAGE_NAME@"
 
 export BUILD_DIR
 export VERSION_NO_SUFFIX
@@ -24,7 +24,7 @@ export PROJECT
 export DESC
 export URL
 export EMAIL
-export PACKAGE_NAME
+export PACKAGE
 
 mkdir tmp
 


### PR DESCRIPTION
## Change Description

`brew` installs formula under `/usr/local/Cellar/${PACKAGE}`, and it removes that path during uninstall. For clean removal, change installed path to sio4.cdt. 